### PR TITLE
Resolving issues with low latency setting

### DIFF
--- a/installer
+++ b/installer
@@ -9,7 +9,7 @@
 # Ask user 
 #
 clear;echo;echo;echo "EMU USB Installer by W.Pasman"
-pathname=`dirname "$0"`
+pathname=$PWD
 cd "$pathname"
 
 


### PR DESCRIPTION
Installer won't work when dirname $0 returns just the dot. In this case cd "$pathname" has no effect.